### PR TITLE
fix(getRewards): use different address for shadow getRewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhedge/v2-sdk",
-  "version": "1.10.13",
+  "version": "1.10.14",
   "license": "MIT",
   "description": "🛠 An SDK for building applications on top of dHEDGE V2",
   "main": "dist/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,7 +98,7 @@ export const stakingAddress: AddressDappNetworkMap = {
     [Dapp.PANCAKECL]: "0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3"
   },
   [Network.SONIC]: {
-    [Dapp.SHADOWCL]: "0xe879d0E44e6873cf4ab71686055a4f6817685f02"
+    [Dapp.SHADOWCL]: "0xe879d0E44e6873cf4ab71686055a4f6817685f02" //specific  for wS/USDC CL
   }
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,9 @@ export const stakingAddress: AddressDappNetworkMap = {
   [Network.BASE]: {
     [Dapp.PANCAKECL]: "0xC6A2Db661D5a5690172d8eB0a7DEA2d3008665A3"
   },
-  [Network.SONIC]: {}
+  [Network.SONIC]: {
+    [Dapp.SHADOWCL]: "0xe879d0E44e6873cf4ab71686055a4f6817685f02"
+  }
 };
 
 export const aaveAddressProvider: AddressDappNetworkMap = {

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -19,7 +19,7 @@ import {
   nonfungiblePositionManagerAddress,
   routerAddress,
   stakingAddress,
-  SYNTHETIX_TRACKING_CODE
+  SYNTHETIX_TRACKING_CODE,
 } from "../config";
 import {
   Dapp,
@@ -30,60 +30,60 @@ import {
   LyraOptionMarket,
   LyraOptionType,
   LyraTradeType,
-  LyraPosition
+  LyraPosition,
 } from "../types";
 
 import { Utils } from "./utils";
 import {
   getDecreaseLiquidityTxData,
   getIncreaseLiquidityTxData,
-  getUniswapV3MintTxData
+  getUniswapV3MintTxData,
 } from "../services/uniswap/V3Liquidity";
 import { getUniswapV3SwapTxData } from "../services/uniswap/V3Trade";
 import {
   getCompleteWithdrawalTxData,
-  getEasySwapperTxData
+  getEasySwapperTxData,
 } from "../services/toros/easySwapper";
 import { getAaveV3ClaimTxData } from "../services/aave/incentives";
 import {
   getClOwner,
   getVelodromeAddLiquidityTxData,
-  getVelodromeRemoveLiquidityTxData
+  getVelodromeRemoveLiquidityTxData,
 } from "../services/velodrome/liquidity";
 import {
   getVelodromeClaimTxData,
   getVelodromeCLClaimTxData,
-  getVelodromeStakeTxData
+  getVelodromeStakeTxData,
 } from "../services/velodrome/staking";
 import { getLyraOptionTxData } from "../services/lyra/trade";
 import { getOptionPositions } from "../services/lyra/positions";
 import { getDeadline } from "../utils/deadline";
 import {
   getFuturesChangePositionTxData,
-  getFuturesChangeMarginTxData
+  getFuturesChangeMarginTxData,
 } from "../services/futures";
 import { getFuturesCancelOrderTxData } from "../services/futures/trade";
 import { getOneInchSwapTxData } from "../services/oneInch";
 import {
   getCreateVestTxData,
   getExitVestTxData,
-  getRewardsTxDta
+  getRewardsTxDta,
 } from "../services/ramses/vesting";
 import { getPoolTxOrGasEstimate } from "../utils/contract";
 import {
   cancelOrderViaFlatMoney,
   mintUnitViaFlatMoney,
-  redeemUnitViaFlatMoney
+  redeemUnitViaFlatMoney,
 } from "../services/flatmoney/stableLp";
 import {
   getCompoundV3LendTxData,
-  getCompoundV3WithdrawTxData
+  getCompoundV3WithdrawTxData,
 } from "../services/compound/lending";
 import { getCompoundV3ClaimTxData } from "../services/compound/rewards";
 import {
   getPancakeHarvestClaimTxData,
   getPancakeStakeTxData,
-  getPancakeUnStakeTxData
+  getPancakeUnStakeTxData,
 } from "../services/pancake/staking";
 import { getOdosSwapTxData } from "../services/odos";
 
@@ -130,7 +130,7 @@ export class Pool {
           asset: asset,
           isDeposit: isDeposit,
           balance: result[1][index],
-          rate: result[2][index]
+          rate: result[2][index],
         };
       }
     );
@@ -225,7 +225,7 @@ export class Pool {
     const iERC20 = new ethers.utils.Interface(IERC20.abi);
     const approveTxData = iERC20.encodeFunctionData("approve", [
       routerAddress[this.network][dapp],
-      amount
+      amount,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -254,7 +254,7 @@ export class Pool {
     const iERC20 = new ethers.utils.Interface(IERC20.abi);
     const approveTxData = iERC20.encodeFunctionData("approve", [
       stakingAddress[this.network][dapp],
-      amount
+      amount,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -282,7 +282,7 @@ export class Pool {
     const iERC20 = new ethers.utils.Interface(IERC20.abi);
     const approveTxData = iERC20.encodeFunctionData("approve", [
       nonfungiblePositionManagerAddress[this.network][Dapp.UNISWAPV3],
-      amount
+      amount,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -311,7 +311,7 @@ export class Pool {
     const iERC20 = new ethers.utils.Interface(IERC20.abi);
     const approveTxData = iERC20.encodeFunctionData("approve", [
       spender,
-      amount
+      amount,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -340,7 +340,7 @@ export class Pool {
     const iERC721 = new ethers.utils.Interface(IERC721.abi);
     const approveTxData = iERC721.encodeFunctionData("approve", [
       spender,
-      tokenId
+      tokenId,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -392,7 +392,7 @@ export class Pool {
         break;
       case Dapp.SYNTHETIX:
         const iSynthetix = new ethers.utils.Interface(ISynthetix.abi);
-        const assets = [assetFrom, assetTo].map(asset =>
+        const assets = [assetFrom, assetTo].map((asset) =>
           ethers.utils.formatBytes32String(asset)
         );
         const daoAddress = await this.factory.owner();
@@ -401,7 +401,7 @@ export class Pool {
           amountIn,
           assets[1],
           daoAddress,
-          SYNTHETIX_TRACKING_CODE
+          SYNTHETIX_TRACKING_CODE,
         ]);
         break;
       case Dapp.TOROS:
@@ -438,7 +438,7 @@ export class Pool {
           minAmountOut,
           [assetFrom, assetTo],
           this.address,
-          await getDeadline(this)
+          await getDeadline(this),
         ]);
     }
     const tx = await getPoolTxOrGasEstimate(
@@ -480,7 +480,7 @@ export class Pool {
         0,
         0,
         this.address,
-        await getDeadline(this)
+        await getDeadline(this),
       ]
     );
     const tx = await getPoolTxOrGasEstimate(
@@ -543,7 +543,7 @@ export class Pool {
     const stakeTxData = iMiniChefV2.encodeFunctionData(Transaction.DEPOSIT, [
       poolId,
       amount,
-      this.address
+      this.address,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -576,7 +576,7 @@ export class Pool {
           IBalancerRewardsGauge.abi
         );
         stakeTxData = rewardsGauge.encodeFunctionData("deposit(uint256)", [
-          amount
+          amount,
         ]);
         break;
       case Dapp.VELODROME:
@@ -628,7 +628,7 @@ export class Pool {
     const unStakeTxData = iMiniChefV2.encodeFunctionData(Transaction.WITHDRAW, [
       poolId,
       amount,
-      this.address
+      this.address,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -661,7 +661,7 @@ export class Pool {
       unstakeTxData = getPancakeUnStakeTxData(this, amount.toString());
     } else {
       unstakeTxData = rewardsGauge.encodeFunctionData("withdraw(uint256)", [
-        amount
+        amount,
       ]);
     }
     const tx = await getPoolTxOrGasEstimate(
@@ -695,7 +695,7 @@ export class Pool {
       asset,
       amount,
       this.address,
-      referralCode
+      referralCode,
     ]);
 
     const tx = await getPoolTxOrGasEstimate(
@@ -812,7 +812,7 @@ export class Pool {
       amount,
       2,
       referralCode,
-      this.address
+      this.address,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -843,7 +843,7 @@ export class Pool {
       asset,
       amount,
       2,
-      this.address
+      this.address,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -871,7 +871,7 @@ export class Pool {
     const poolId = await this.utils.getLpPoolId(dapp, asset);
     const harvestTxData = iMiniChefV2.encodeFunctionData(Transaction.HARVEST, [
       poolId,
-      this.address
+      this.address,
     ]);
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -894,12 +894,12 @@ export class Pool {
     estimateGas = false
   ): Promise<any> {
     const currentAssetsEnabled = await this.getComposition();
-    const currentAssets = currentAssetsEnabled.map(e =>
+    const currentAssets = currentAssetsEnabled.map((e) =>
       e.asset.toLocaleLowerCase()
     );
-    const newAssets = assets.map(e => e.asset.toLocaleLowerCase());
-    const removedAssets = currentAssets.filter(e => !newAssets.includes(e));
-    const changedAssets = assets.map(e => [e.asset, e.isDeposit]);
+    const newAssets = assets.map((e) => e.asset.toLocaleLowerCase());
+    const removedAssets = currentAssets.filter((e) => !newAssets.includes(e));
+    const changedAssets = assets.map((e) => [e.asset, e.isDeposit]);
 
     if (estimateGas) {
       return await this.managerLogic.estimateGas.changeAssets(
@@ -1056,7 +1056,7 @@ export class Pool {
       [
         stakingAddress[this.network][Dapp.AAVEV3] as string,
         claimTxData,
-        options
+        options,
       ],
       estimateGas
     );
@@ -1081,7 +1081,7 @@ export class Pool {
       [
         stakingAddress[this.network][Dapp.COMPOUNDV3] as string,
         claimTxData,
-        options
+        options,
       ],
       estimateGas
     );
@@ -1151,7 +1151,7 @@ export class Pool {
       [
         nonfungiblePositionManagerAddress[this.network][dapp],
         mintTxData,
-        options
+        options,
       ],
       estimateGas
     );
@@ -1384,7 +1384,7 @@ export class Pool {
   ): Promise<any> {
     const claimAddress =
       dapp === Dapp.SHADOWCL
-        ? stakingAddress[this.network][dapp]
+        ? stakingAddress[this.network][dapp] //specific  for wS/USDC CL
         : nonfungiblePositionManagerAddress[this.network][dapp];
     const tx = await getPoolTxOrGasEstimate(
       this,
@@ -1463,7 +1463,7 @@ export class Pool {
           amountB,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );
@@ -1499,7 +1499,7 @@ export class Pool {
           amount,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );
@@ -1538,7 +1538,7 @@ export class Pool {
           amountB,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );
@@ -1574,7 +1574,7 @@ export class Pool {
           amount,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );
@@ -1615,7 +1615,7 @@ export class Pool {
           amountB,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );
@@ -1653,7 +1653,7 @@ export class Pool {
           amount,
           isStable
         ),
-        options
+        options,
       ],
       estimateGas
     );

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -1382,13 +1382,13 @@ export class Pool {
     options: any = null,
     estimateGas = false
   ): Promise<any> {
+    const claimAddress =
+      dapp === Dapp.SHADOWCL
+        ? stakingAddress[this.network][dapp]
+        : nonfungiblePositionManagerAddress[this.network][dapp];
     const tx = await getPoolTxOrGasEstimate(
       this,
-      [
-        nonfungiblePositionManagerAddress[this.network][dapp],
-        getRewardsTxDta(tokenId, rewards),
-        options
-      ],
+      [claimAddress, getRewardsTxDta(tokenId, rewards), options],
       estimateGas
     );
     return tx;


### PR DESCRIPTION
Reward claiming for Shadow CL on Nonfungiblepositionmanager didn't work:
https://sonicscan.org/tx/0x55342cca6e143add7ebd48ab7a11fdace543e6d922c366d64cd7d804a31cedac


On a different address, it is claiming xShadow:
https://sonicscan.org/tx/0xec366cba9c2f5cea5db5d4343cdcc33b8232347be58cf856ce3dfc99a4786021